### PR TITLE
Build on older Ubuntu to get glibc 2.31

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,8 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    # We use 20.04 so we build with glibc 2.31 to support debian bullseye
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Fix

```
./vendor/syslog-wrapper: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by ./vendor/syslog-wrapper)
```

when run on Debian bullseye.